### PR TITLE
Rename project from npm-dep-manager to trawl

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -40,7 +40,7 @@ The key differentiator versus existing tools is the **zero-interaction warning m
 ## Project Structure
 
 ```
-npm-dep-manager/
+trawl/
 ├── .vscode/
 │   ├── launch.json          # F5 debug configuration for Extension Development Host
 │   └── tasks.json           # Build task wired to esbuild watch mode
@@ -154,7 +154,7 @@ npm install -g @vscode/vsce
 vsce package
 ```
 
-This runs the `vscode:prepublish` script (which type-checks and creates a minified production build), then packages everything into a file like `npm-dep-manager-0.1.0.vsix`.
+This runs the `vscode:prepublish` script (which type-checks and creates a minified production build), then packages everything into a file like `trawl-0.1.0.vsix`.
 
 The `.vscodeignore` file controls what goes into the package. Source files, `node_modules`, and config files are excluded — only `dist/extension.js`, `package.json`, and `README.md` are included, keeping the package small (~17 KB).
 
@@ -172,10 +172,10 @@ The `.vscodeignore` file controls what goes into the package. Source files, `nod
 
 ```bash
 # VS Code
-code --install-extension npm-dep-manager-0.1.0.vsix
+code --install-extension trawl-0.1.0.vsix
 
 # Cursor
-cursor --install-extension npm-dep-manager-0.1.0.vsix
+cursor --install-extension trawl-0.1.0.vsix
 ```
 
 ### 3. Bump the version
@@ -238,7 +238,7 @@ npx ovsx create-namespace <publisher-name> -p <token>
 vsce package
 
 # Publish the .vsix
-npx ovsx publish npm-dep-manager-0.1.0.vsix -p <token>
+npx ovsx publish trawl-0.1.0.vsix -p <token>
 ```
 
 ### Option C: GitHub Releases (private / manual distribution)

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "displayName": "Trawl - NPM Dependency Manager",
   "description": "Zero-click outdated dependency warnings and version autocomplete for package.json",
   "version": "0.1.0",
-  "publisher": "VoidWorks",
+  "publisher": "JensAstrup",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VoidWorksIO/trawl"
+    "url": "https://github.com/JensAstrup/trawl"
   },
     "scripts": {
     "vscode:prepublish": "npm run package",
@@ -41,11 +41,11 @@
   "contributes": {
     "commands": [
       {
-        "command": "npmDepManager.checkOutdated",
+        "command": "trawl.checkOutdated",
         "title": "NPM: Check Outdated Dependencies"
       },
       {
-        "command": "npmDepManager.refreshCache",
+        "command": "trawl.refreshCache",
         "title": "NPM: Refresh Dependency Cache"
       }
     ],

--- a/src/code-actions.ts
+++ b/src/code-actions.ts
@@ -21,7 +21,7 @@ export class VersionQuickFixProvider implements vscode.CodeActionProvider {
     const actions: vscode.CodeAction[] = [];
 
     for (const diagnostic of context.diagnostics) {
-      if (diagnostic.source !== 'npm-dep-manager') continue;
+      if (diagnostic.source !== 'trawl') continue;
 
       const depName = (diagnostic as any)._depName as string | undefined;
       const suggestedVersion = (diagnostic as any)._suggestedVersion as string | undefined;

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -25,7 +25,7 @@ export function getAnalysisCache() {
  * Initialize the diagnostics system. Called from extension activate().
  */
 export function initDiagnostics(context: vscode.ExtensionContext): vscode.DiagnosticCollection {
-  diagnosticCollection = vscode.languages.createDiagnosticCollection('npm-dep-manager');
+  diagnosticCollection = vscode.languages.createDiagnosticCollection('trawl');
   context.subscriptions.push(diagnosticCollection);
 
   // Analyze all currently open package.json files
@@ -177,7 +177,7 @@ async function analyzeDocument(document: vscode.TextDocument): Promise<void> {
     const message = formatDiagnosticMessage(dep, analysis, suggested);
 
     const diagnostic = new vscode.Diagnostic(range, message, severity);
-    diagnostic.source = 'npm-dep-manager';
+    diagnostic.source = 'trawl';
     diagnostic.code = {
       value: analysis.updateType,
       target: vscode.Uri.parse(info.npmUrl),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,9 +50,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register commands
   context.subscriptions.push(
-    vscode.commands.registerCommand('npmDepManager.checkOutdated', async () => {
+    vscode.commands.registerCommand('trawl.checkOutdated', async () => {
       await refreshAllDiagnostics();
-      vscode.window.showInformationMessage('NPM Dependency Manager: Dependencies checked.');
+      vscode.window.showInformationMessage('Trawl: Dependencies checked.');
     })
   );
 
@@ -60,25 +60,25 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.commands.registerCommand('npmDepManager.refreshCache', async () => {
       clearCache();
       await refreshAllDiagnostics();
-      vscode.window.showInformationMessage('NPM Dependency Manager: Cache cleared and dependencies refreshed.');
+      vscode.window.showInformationMessage('Trawl: Cache cleared and dependencies refreshed.');
     })
   );
 
   // Watch for configuration changes
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((event) => {
-      if (event.affectsConfiguration('npmDepManager')) {
+      if (event.affectsConfiguration('trawl')) {
         applyConfig();
         refreshAllDiagnostics();
       }
     })
   );
 
-  console.log('NPM Dependency Manager activated');
+  console.log('Trawl activated');
 }
 
 function applyConfig(): void {
-  const config = vscode.workspace.getConfiguration('npmDepManager');
+  const config = vscode.workspace.getConfiguration('trawl');
   const ttl = config.get<number>('cacheTTLMinutes', 30);
   setCacheTTL(ttl);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,7 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('npmDepManager.refreshCache', async () => {
+    vscode.commands.registerCommand('trawl.refreshCache', async () => {
       clearCache();
       await refreshAllDiagnostics();
       vscode.window.showInformationMessage('Trawl: Cache cleared and dependencies refreshed.');

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -131,7 +131,7 @@ function fetchFromRegistry(packageName: string): Promise<NpmPackageInfo> {
       {
         headers: {
           Accept: 'application/json',
-          'User-Agent': 'npm-dep-manager-vscode/0.1.0',
+          'User-Agent': 'trawl-vscode/0.1.0',
         },
         timeout: 10000,
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated project documentation to reflect new naming.

* **Chores**
  * Rebranded configuration keys and commands throughout the extension.
  * Updated diagnostic labels and service request headers to use new project identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->